### PR TITLE
remove console.log

### DIFF
--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -53,6 +53,7 @@ export default defineConfig({
   //   },
   esbuild: {
     loader: 'tsx', // Or 'jsx' if you're not using TypeScript
+    pure: ['console.log'],
   },
   optimizeDeps: {
     include: ['common'],


### PR DESCRIPTION
Does it make sense to remove at least the console.log in production?