### PR TITLE
Grade field of A+ grades can't be edited

### DIFF
--- a/server/src/controllers/grades.ts
+++ b/server/src/controllers/grades.ts
@@ -303,6 +303,13 @@ export const editGrade = async (
     );
   }
 
+  if (gradeData.aplusGradeSourceId !== null && grade !== undefined) {
+    throw new ApiError(
+      'Grade field of A+ grades cannot be edited',
+      HttpCode.BadRequest
+    );
+  }
+
   await gradeData
     .set({
       grade: grade ?? gradeData.grade,

--- a/server/test/controllers/grades.test.ts
+++ b/server/test/controllers/grades.test.ts
@@ -503,6 +503,23 @@ describe('Test PUT /v1/courses/:courseId/grades/:gradeId - edit a grade', () => 
     await responseTests.testBadRequest(url, cookies.adminCookie).put(data);
   });
 
+  it('should respond with 400 if trying to edit the grade field of an A+ grade', async () => {
+    const user = await createData.createUser();
+    const gradeId = await createData.createGrade(
+      user.id,
+      aplusCoursePartId,
+      TEACHER_ID,
+      undefined,
+      undefined,
+      aplusGradeSourceId
+    );
+
+    const url = `/v1/courses/${courseId}/grades/${gradeId}`;
+    await responseTests
+      .testBadRequest(url, cookies.adminCookie)
+      .put({grade: 5});
+  });
+
   it('should respond with 401 or 403 if not authorized', async () => {
     let url = `/v1/courses/${courseId}/grades/${editGradeId}`;
     const data = {comment: 'not edited'};


### PR DESCRIPTION
**Description of changes**
<!--
Short description of the changes implemented by this pull request.
-->

**Requirements**
<!--
Tick all the completed boxes or indicate that the item is not relevant to this
pull request by removing it from the list or by adding a short explanation.
-->
- [ ] I've written tests for new functionality
- [ ] I have updated documentation
- [ ] My changes to the UI are in accordance with the [design guidelines](
      https://github.com/aalto-grades/base-repository/wiki/Design-Guidelines)
- [ ] I have marked all new files with the correct [license](
      https://github.com/aalto-grades/base-repository/wiki/Licensing-Guidelines)

**Related issues**
Fixes #691 
