### PR TITLE
Don't allow adding the same A+ grade source twice from the client

### DIFF
--- a/client/src/components/course-view/AddAplusGradeSourceDialog.tsx
+++ b/client/src/components/course-view/AddAplusGradeSourceDialog.tsx
@@ -12,7 +12,11 @@ import {
 import {JSX, useState} from 'react';
 import {useParams} from 'react-router-dom';
 
-import {NewAplusGradeSourceData, AplusCourseData} from '@/common/types';
+import {
+  NewAplusGradeSourceData,
+  AplusCourseData,
+  AplusGradeSourceData,
+} from '@/common/types';
 import SelectAplusCourse from './SelectAplusCourse';
 import SelectAplusGradeSource from './SelectAplusGradeSource';
 import {
@@ -25,11 +29,13 @@ import AplusTokenDialog from '../shared/AplusTokenDialog';
 type PropsType = {
   handleClose: () => void;
   coursePartId: number | null;
+  aplusGradeSources: AplusGradeSourceData[];
 };
 
 const AddAplusGradeSourceDialog = ({
   handleClose,
   coursePartId,
+  aplusGradeSources,
 }: PropsType): JSX.Element => {
   const {courseId} = useParams() as {courseId: string};
   const aplusCourses = useFetchAplusCourses({enabled: !!getAplusToken()});
@@ -63,6 +69,7 @@ const AddAplusGradeSourceDialog = ({
           {step === 1 && aplusCourse && (
             <SelectAplusGradeSource
               aplusCourse={aplusCourse}
+              aplusGradeSources={aplusGradeSources}
               handleSelect={(aplusGradeSource: NewAplusGradeSourceData) => {
                 if (coursePartId !== null) {
                   addAplusGradeSources.mutate([

--- a/client/src/components/course-view/CoursePartsView.tsx
+++ b/client/src/components/course-view/CoursePartsView.tsx
@@ -63,9 +63,13 @@ const CoursePartsView = (): JSX.Element => {
   const [editing, setEditing] = useState<boolean>(false);
   const [addDialogOpen, setAddDialogOpen] = useState<boolean>(false);
   const [aplusDialogOpen, setAplusDialogOpen] = useState<boolean>(false);
-  const [addAplusSourcesTo, setAddAplusSourcesTo] = useState<number | null>(
-    null
-  );
+  const [addAplusSourcesTo, setAddAplusSourcesTo] = useState<{
+    coursePartId: number | null;
+    aplusGradeSources: AplusGradeSourceData[];
+  }>({
+    coursePartId: null,
+    aplusGradeSources: [],
+  });
   const [viewAplusSourcesOpen, setViewAplusSourcesOpen] =
     useState<boolean>(false);
   const [aplusGradeSources, setAplusGradeSources] = useState<
@@ -211,7 +215,12 @@ const CoursePartsView = (): JSX.Element => {
       <GridActionsCellItem
         icon={<AddCircle />}
         label="Add A+ grade source"
-        onClick={() => setAddAplusSourcesTo(params.row.id)}
+        onClick={() =>
+          setAddAplusSourcesTo({
+            coursePartId: params.row.id,
+            aplusGradeSources: params.row.aplusGradeSources,
+          })
+        }
       />
     );
 
@@ -322,8 +331,14 @@ const CoursePartsView = (): JSX.Element => {
         open={aplusDialogOpen}
       />
       <AddAplusGradeSourceDialog
-        handleClose={() => setAddAplusSourcesTo(null)}
-        coursePartId={addAplusSourcesTo}
+        handleClose={() =>
+          setAddAplusSourcesTo({
+            coursePartId: null,
+            aplusGradeSources: [],
+          })
+        }
+        coursePartId={addAplusSourcesTo.coursePartId}
+        aplusGradeSources={addAplusSourcesTo.aplusGradeSources}
       />
       <ViewAplusGradeSourcesDialog
         handleClose={() => setViewAplusSourcesOpen(false)}

--- a/client/src/components/course-view/SelectAplusGradeSource.tsx
+++ b/client/src/components/course-view/SelectAplusGradeSource.tsx
@@ -14,21 +14,59 @@ import {JSX} from 'react';
 
 import {
   AplusCourseData,
-  NewAplusGradeSourceData,
+  AplusGradeSourceData,
   AplusGradeSourceType,
+  NewAplusGradeSourceData,
 } from '@/common/types';
 import {useFetchAplusExerciseData} from '../../hooks/useApi';
+import {newAplusGradeSource} from '../../utils/utils';
 
 type PropsType = {
   aplusCourse: AplusCourseData;
+  aplusGradeSources: AplusGradeSourceData[];
   handleSelect: (source: NewAplusGradeSourceData) => void;
 };
 
 const SelectAplusGradeSource = ({
   aplusCourse,
+  aplusGradeSources,
   handleSelect,
 }: PropsType): JSX.Element => {
   const aplusExerciseData = useFetchAplusExerciseData(aplusCourse.id);
+
+  const isDisabled = (newSource: NewAplusGradeSourceData): boolean => {
+    for (const source of aplusGradeSources) {
+      type ComparisonType = {
+        aplusCourse: AplusCourseData;
+        sourceType: AplusGradeSourceType;
+        moduleId?: number;
+        exerciseId?: number;
+        difficulty?: string;
+      };
+
+      const a: ComparisonType = source;
+      const b: ComparisonType = newSource;
+      if (
+        a.sourceType === b.sourceType &&
+        a.aplusCourse.id === b.aplusCourse.id
+      ) {
+        switch (a.sourceType) {
+          case AplusGradeSourceType.FullPoints:
+            return true;
+          case AplusGradeSourceType.Module:
+            if (a.moduleId === b.moduleId) return true;
+            break;
+          case AplusGradeSourceType.Exercise:
+            if (a.exerciseId === b.exerciseId) return true;
+            break;
+          case AplusGradeSourceType.Difficulty:
+            if (a.difficulty === b.difficulty) return true;
+            break;
+        }
+      }
+    }
+    return false;
+  };
 
   if (aplusExerciseData.data === undefined) return <></>;
 
@@ -40,13 +78,8 @@ const SelectAplusGradeSource = ({
         </AccordionSummary>
         <AccordionDetails>
           <Button
-            onClick={() =>
-              handleSelect({
-                coursePartId: -1,
-                aplusCourse: aplusCourse,
-                sourceType: AplusGradeSourceType.FullPoints,
-              })
-            }
+            disabled={isDisabled(newAplusGradeSource(aplusCourse, {}))}
+            onClick={() => handleSelect(newAplusGradeSource(aplusCourse, {}))}
           >
             Full points
           </Button>
@@ -60,14 +93,11 @@ const SelectAplusGradeSource = ({
           <FormGroup>
             {aplusExerciseData.data.modules.map(module => (
               <Button
+                disabled={isDisabled(
+                  newAplusGradeSource(aplusCourse, {module})
+                )}
                 onClick={() =>
-                  handleSelect({
-                    coursePartId: -1,
-                    aplusCourse: aplusCourse,
-                    sourceType: AplusGradeSourceType.Module,
-                    moduleId: module.id,
-                    moduleName: module.name,
-                  })
+                  handleSelect(newAplusGradeSource(aplusCourse, {module}))
                 }
               >
                 {module.name}
@@ -85,14 +115,11 @@ const SelectAplusGradeSource = ({
             {aplusExerciseData.data.modules.map(module =>
               module.exercises.map(exercise => (
                 <Button
+                  disabled={isDisabled(
+                    newAplusGradeSource(aplusCourse, {exercise})
+                  )}
                   onClick={() =>
-                    handleSelect({
-                      coursePartId: -1,
-                      aplusCourse: aplusCourse,
-                      sourceType: AplusGradeSourceType.Exercise,
-                      exerciseId: exercise.id,
-                      exerciseName: exercise.name,
-                    })
+                    handleSelect(newAplusGradeSource(aplusCourse, {exercise}))
                   }
                 >
                   {exercise.name}
@@ -111,13 +138,11 @@ const SelectAplusGradeSource = ({
             <FormGroup>
               {aplusExerciseData.data.difficulties.map(difficulty => (
                 <Button
+                  disabled={isDisabled(
+                    newAplusGradeSource(aplusCourse, {difficulty})
+                  )}
                   onClick={() =>
-                    handleSelect({
-                      coursePartId: -1,
-                      aplusCourse: aplusCourse,
-                      sourceType: AplusGradeSourceType.Difficulty,
-                      difficulty: difficulty,
-                    })
+                    handleSelect(newAplusGradeSource(aplusCourse, {difficulty}))
                   }
                 >
                   {difficulty}

--- a/client/src/components/course-view/SelectAplusGradeSource.tsx
+++ b/client/src/components/course-view/SelectAplusGradeSource.tsx
@@ -15,9 +15,9 @@ import {JSX} from 'react';
 import {
   AplusCourseData,
   AplusGradeSourceData,
-  AplusGradeSourceType,
   NewAplusGradeSourceData,
 } from '@/common/types';
+import {aplusGradeSourcesEqual} from '@/common/util/aplus';
 import {useFetchAplusExerciseData} from '../../hooks/useApi';
 import {newAplusGradeSource} from '../../utils/utils';
 
@@ -36,33 +36,8 @@ const SelectAplusGradeSource = ({
 
   const isDisabled = (newSource: NewAplusGradeSourceData): boolean => {
     for (const source of aplusGradeSources) {
-      type ComparisonType = {
-        aplusCourse: AplusCourseData;
-        sourceType: AplusGradeSourceType;
-        moduleId?: number;
-        exerciseId?: number;
-        difficulty?: string;
-      };
-
-      const a: ComparisonType = source;
-      const b: ComparisonType = newSource;
-      if (
-        a.sourceType === b.sourceType &&
-        a.aplusCourse.id === b.aplusCourse.id
-      ) {
-        switch (a.sourceType) {
-          case AplusGradeSourceType.FullPoints:
-            return true;
-          case AplusGradeSourceType.Module:
-            if (a.moduleId === b.moduleId) return true;
-            break;
-          case AplusGradeSourceType.Exercise:
-            if (a.exerciseId === b.exerciseId) return true;
-            break;
-          case AplusGradeSourceType.Difficulty:
-            if (a.difficulty === b.difficulty) return true;
-            break;
-        }
+      if (aplusGradeSourcesEqual(newSource, source)) {
+        return true;
       }
     }
     return false;

--- a/client/src/components/course-view/SelectAplusGradeSources.tsx
+++ b/client/src/components/course-view/SelectAplusGradeSources.tsx
@@ -13,12 +13,9 @@ import {
 } from '@mui/material';
 import {JSX} from 'react';
 
-import {
-  AplusCourseData,
-  NewAplusGradeSourceData,
-  AplusGradeSourceType,
-} from '@/common/types';
+import {AplusCourseData, NewAplusGradeSourceData} from '@/common/types';
 import {useFetchAplusExerciseData} from '../../hooks/useApi';
+import {newAplusGradeSource} from '../../utils/utils';
 
 type PropsType = {
   aplusCourse: AplusCourseData;
@@ -48,11 +45,11 @@ const SelectAplusGradeSources = ({
             control={
               <Checkbox
                 onChange={e =>
-                  handleChange(e.target.checked, 'A+ Course', {
-                    coursePartId: -1,
-                    aplusCourse: aplusCourse,
-                    sourceType: AplusGradeSourceType.FullPoints,
-                  })
+                  handleChange(
+                    e.target.checked,
+                    'A+ Course',
+                    newAplusGradeSource(aplusCourse, {})
+                  )
                 }
               />
             }
@@ -74,13 +71,7 @@ const SelectAplusGradeSources = ({
                       handleChange(
                         e.target.checked,
                         `A+ Module: ${module.name}`,
-                        {
-                          coursePartId: -1,
-                          aplusCourse: aplusCourse,
-                          sourceType: AplusGradeSourceType.Module,
-                          moduleId: module.id,
-                          moduleName: module.name,
-                        }
+                        newAplusGradeSource(aplusCourse, {module})
                       )
                     }
                   />
@@ -106,13 +97,7 @@ const SelectAplusGradeSources = ({
                         handleChange(
                           e.target.checked,
                           `A+ Exercise: ${exercise.name}`,
-                          {
-                            coursePartId: -1,
-                            aplusCourse: aplusCourse,
-                            sourceType: AplusGradeSourceType.Exercise,
-                            exerciseId: exercise.id,
-                            exerciseName: exercise.name,
-                          }
+                          newAplusGradeSource(aplusCourse, {exercise})
                         )
                       }
                     />
@@ -139,12 +124,7 @@ const SelectAplusGradeSources = ({
                         handleChange(
                           e.target.checked,
                           `A+ Difficulty: ${difficulty}`,
-                          {
-                            coursePartId: -1,
-                            aplusCourse: aplusCourse,
-                            sourceType: AplusGradeSourceType.Difficulty,
-                            difficulty: difficulty,
-                          }
+                          newAplusGradeSource(aplusCourse, {difficulty})
                         )
                       }
                     />

--- a/client/src/utils/utils.ts
+++ b/client/src/utils/utils.ts
@@ -3,11 +3,14 @@
 // SPDX-License-Identifier: MIT
 
 import {
+  AplusCourseData,
+  AplusGradeSourceType,
   AuthData,
   CourseData,
   CourseRoleType,
   GradingScale,
   Language,
+  NewAplusGradeSourceData,
 } from '@/common/types';
 import {LanguageOption} from '../types';
 
@@ -84,3 +87,55 @@ export const setAplusToken = (token: string): void =>
 
 export const getAplusToken = (): string | null =>
   localStorage.getItem('Aplus-Token');
+
+export const newAplusGradeSource = (
+  aplusCourse: AplusCourseData,
+  {
+    module,
+    exercise,
+    difficulty,
+  }: {
+    module?: {
+      id: number;
+      name: string;
+    };
+    exercise?: {
+      id: number;
+      name: string;
+    };
+    difficulty?: string;
+  }
+): NewAplusGradeSourceData => {
+  const base = {coursePartId: -1, aplusCourse: aplusCourse};
+
+  if (module !== undefined) {
+    return {
+      ...base,
+      sourceType: AplusGradeSourceType.Module,
+      moduleId: module.id,
+      moduleName: module.name,
+    };
+  }
+
+  if (exercise !== undefined) {
+    return {
+      ...base,
+      sourceType: AplusGradeSourceType.Exercise,
+      exerciseId: exercise.id,
+      exerciseName: exercise.name,
+    };
+  }
+
+  if (difficulty !== undefined) {
+    return {
+      ...base,
+      sourceType: AplusGradeSourceType.Difficulty,
+      difficulty: difficulty,
+    };
+  }
+
+  return {
+    ...base,
+    sourceType: AplusGradeSourceType.FullPoints,
+  };
+};

--- a/common/util/aplus.ts
+++ b/common/util/aplus.ts
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: 2024 The Aalto Grades Developers
+//
+// SPDX-License-Identifier: MIT
+
+import {
+  AplusGradeSourceData,
+  AplusGradeSourceType,
+  NewAplusGradeSourceData,
+} from '../types';
+
+export const aplusGradeSourcesEqual = (
+  a: AplusGradeSourceData | NewAplusGradeSourceData,
+  b: AplusGradeSourceData | NewAplusGradeSourceData
+): boolean => {
+  if (a.sourceType === b.sourceType && a.aplusCourse.id === b.aplusCourse.id) {
+    switch (a.sourceType) {
+      case AplusGradeSourceType.FullPoints:
+        return true;
+      case AplusGradeSourceType.Module:
+        if (a.moduleId === (b as {moduleId: number}).moduleId) {
+          return true;
+        }
+        break;
+      case AplusGradeSourceType.Exercise:
+        if (a.exerciseId === (b as {exerciseId: number}).exerciseId) {
+          return true;
+        }
+        break;
+      case AplusGradeSourceType.Difficulty:
+        if (a.difficulty === (b as {difficulty: string}).difficulty) {
+          return true;
+        }
+        break;
+    }
+  }
+
+  return false;
+};

--- a/server/src/controllers/aplus.ts
+++ b/server/src/controllers/aplus.ts
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: MIT
 
 import {Request, Response} from 'express';
-import assert from 'node:assert/strict';
 import {ForeignKeyConstraintError} from 'sequelize';
 import {z} from 'zod';
 import {TypedRequestBody} from 'zod-express-middleware';

--- a/server/src/controllers/aplus.ts
+++ b/server/src/controllers/aplus.ts
@@ -18,6 +18,7 @@ import {
   NewAplusGradeSourceData,
   NewGrade,
 } from '@/common/types';
+import {aplusGradeSourcesEqual} from '@/common/util/aplus';
 import {
   fetchFromAplus,
   parseAplusGradeSource,
@@ -126,9 +127,7 @@ export const addAplusGradeSources = async (
     for (const other of newGradeSources.filter(
       source => source !== newGradeSource
     )) {
-      try {
-        assert.notDeepStrictEqual(newGradeSource, other);
-      } catch (e) {
+      if (aplusGradeSourcesEqual(newGradeSource, other)) {
         throw new ApiError(
           `attempted to add the same A+ grade source ${JSON.stringify(newGradeSource)} twice`,
           HttpCode.Conflict
@@ -144,18 +143,7 @@ export const addAplusGradeSources = async (
 
     for (const partGradeSource of partGradeSourcesById[coursePart.id]) {
       const parsed = parseAplusGradeSource(partGradeSource);
-      try {
-        // This comparison doesn't work without JSON magic and I don't know why
-        assert.notDeepStrictEqual(
-          JSON.parse(JSON.stringify(newGradeSource)),
-          JSON.parse(
-            JSON.stringify({
-              ...parsed,
-              id: undefined,
-            })
-          )
-        );
-      } catch (e) {
+      if (aplusGradeSourcesEqual(newGradeSource, parsed)) {
         throw new ApiError(
           `course part with ID ${parsed.coursePartId} ` +
             `already has the A+ grade source ${JSON.stringify(newGradeSource)}`,


### PR DESCRIPTION
**Description of changes**
Disallows adding the same A+ grade source to the same course part twice from the client.

**Requirements**
<!--
Tick all the completed boxes or indicate that the item is not relevant to this
pull request by removing it from the list or by adding a short explanation.
-->
- [x] I have marked all new files with the correct [license](
      https://github.com/aalto-grades/base-repository/wiki/Licensing-Guidelines)

**Related issues**
Fixes #768 
