### PR TITLE
Fetch grades from multiple A+ sources

### DIFF
--- a/server/src/controllers/aplus.ts
+++ b/server/src/controllers/aplus.ts
@@ -10,6 +10,7 @@ import {TypedRequestBody} from 'zod-express-middleware';
 import {
   AplusCourseData,
   AplusExerciseData,
+  AplusGradeSourceData,
   AplusGradeSourceType,
   HttpCode,
   IdSchema,
@@ -226,7 +227,7 @@ export const fetchAplusGrades = async (
 
     const gradeSources = await AplusGradeSource.findAll({
       where: {coursePartId: coursePart.id},
-    });
+    }) as (AplusGradeSourceData & {date: Date})[];
 
     if (gradeSources.length === 0) {
       throw new ApiError(
@@ -261,12 +262,6 @@ export const fetchAplusGrades = async (
             break;
 
           case AplusGradeSourceType.Module:
-            if (!gradeSource.moduleId) {
-              throw new ApiError(
-                `grade source with ID ${gradeSource.id} has module type but does not define moduleId`,
-                HttpCode.InternalServerError
-              );
-            }
             for (const module of student.modules) {
               if (module.id === gradeSource.moduleId) {
                 grade = module.points;
@@ -282,12 +277,6 @@ export const fetchAplusGrades = async (
             break;
 
           case AplusGradeSourceType.Exercise:
-            if (!gradeSource.exerciseId) {
-              throw new ApiError(
-                `grade source with ID ${gradeSource.id} has exercise type but does not define exerciseId`,
-                HttpCode.InternalServerError
-              );
-            }
             for (const module of student.modules) {
               for (const exercise of module.exercises) {
                 if (exercise.id === gradeSource.exerciseId) {
@@ -304,12 +293,6 @@ export const fetchAplusGrades = async (
             break;
 
           case AplusGradeSourceType.Difficulty:
-            if (!gradeSource.difficulty) {
-              throw new ApiError(
-                `grade source with ID ${gradeSource.id} has difficulty type but does not define difficulty`,
-                HttpCode.InternalServerError
-              );
-            }
             grade = student.points_by_difficulty[gradeSource.difficulty] ?? 0;
             break;
         }

--- a/server/src/controllers/aplus.ts
+++ b/server/src/controllers/aplus.ts
@@ -225,9 +225,9 @@ export const fetchAplusGrades = async (
       String(coursePartId)
     );
 
-    const gradeSources = await AplusGradeSource.findAll({
+    const gradeSources = (await AplusGradeSource.findAll({
       where: {coursePartId: coursePart.id},
-    }) as (AplusGradeSourceData & {date: Date})[];
+    })) as (AplusGradeSourceData & {date: Date})[];
 
     if (gradeSources.length === 0) {
       throw new ApiError(

--- a/server/src/controllers/aplus.ts
+++ b/server/src/controllers/aplus.ts
@@ -254,7 +254,7 @@ export const fetchAplusGrades = async (
           continue;
         }
 
-        let grade: number | undefined;
+        let grade: number | null = null;
         switch (gradeSource.sourceType) {
           case AplusGradeSourceType.FullPoints:
             grade = student.points;
@@ -273,7 +273,7 @@ export const fetchAplusGrades = async (
                 break;
               }
             }
-            if (grade === undefined) {
+            if (grade === null) {
               throw new ApiError(
                 `A+ course with ID ${aplusCourseId} has no module with ID ${gradeSource.moduleId}`,
                 HttpCode.InternalServerError
@@ -295,7 +295,7 @@ export const fetchAplusGrades = async (
                 }
               }
             }
-            if (grade === undefined) {
+            if (grade === null) {
               throw new ApiError(
                 `A+ course with ID ${aplusCourseId} has no exercise with ID ${gradeSource.exerciseId}`,
                 HttpCode.InternalServerError

--- a/server/test/controllers/aplus.test.ts
+++ b/server/test/controllers/aplus.test.ts
@@ -16,7 +16,6 @@ import {
   NewGradeArraySchema,
 } from '@/common/types';
 import {app} from '../../src/app';
-import {APLUS_API_URL} from '../../src/configs/environment';
 import AplusGradeSource from '../../src/database/models/aplusGradeSource';
 import {createData} from '../util/createData';
 import {TEACHER_ID} from '../util/general';
@@ -81,10 +80,8 @@ beforeAll(async () => {
 
   // eslint-disable-next-line @typescript-eslint/require-await
   mockedAxios.get.mockImplementation(async url => {
-    const urlPoints = `${APLUS_API_URL}/courses/1/points?format=json`;
-
     /* eslint-disable camelcase */
-    if (url === urlPoints) {
+    if (url.endsWith('/points?format=json')) {
       return {
         data: {
           results: [
@@ -618,6 +615,23 @@ describe('Test GET /v1/courses/:courseId/aplus-fetch - Fetch grades from A+', ()
       exerciseCoursePartId,
       difficultyCoursePartId,
     ]);
+  });
+
+  it('should fetch grades from multiple sources', async () => {
+    const [[coursePartId]] = await createData.createAplusGradeSources(courseId);
+    await AplusGradeSource.create({
+      coursePartId,
+      aplusCourse: {
+        id: 2,
+        courseCode: 'CS-123',
+        name: 'The Name',
+        instance: '1970',
+        url: 'https://plus.cs.aalto.fi',
+      },
+      sourceType: AplusGradeSourceType.FullPoints,
+    });
+
+    await successTest([coursePartId]);
   });
 
   it('should respond with 400 if A+ token parsing fails', async () => {

--- a/server/test/controllers/aplus.test.ts
+++ b/server/test/controllers/aplus.test.ts
@@ -636,6 +636,7 @@ describe('Test GET /v1/courses/:courseId/aplus-fetch - Fetch grades from A+', ()
         url: 'https://plus.cs.aalto.fi',
       },
       sourceType: AplusGradeSourceType.FullPoints,
+      date: new Date(),
     });
 
     await successTest([coursePartId]);


### PR DESCRIPTION
**Description of changes**
Updates the A+ grade fetching endpoint to fetch grades from all sources of the course parts. In the future, we may want to allow selecting which sources to fetch from, or teachers will have to delete sources that they don't care about anymore to not fetch from them.

**Requirements**
<!--
Tick all the completed boxes or indicate that the item is not relevant to this
pull request by removing it from the list or by adding a short explanation.
-->
- [x] I've written tests for new functionality

**Related issues**
Fixes #673 