### PR TITLE
Allow deleting course parts with A+ sources

### DIFF
--- a/server/src/database/migrations/00019-change-aplus-grade-source-constraint.ts
+++ b/server/src/database/migrations/00019-change-aplus-grade-source-constraint.ts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 The Aalto Grades Developers
+// SPDX-FileCopyrightText: 2024 The Aalto Grades Developers
 //
 // SPDX-License-Identifier: MIT
 

--- a/server/src/database/migrations/00019-change-aplus-grade-source-constraint.ts
+++ b/server/src/database/migrations/00019-change-aplus-grade-source-constraint.ts
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: 2022 The Aalto Grades Developers
+//
+// SPDX-License-Identifier: MIT
+
+/* eslint camelcase: off */
+
+import {QueryInterface} from 'sequelize';
+
+import logger from '../../configs/winston';
+
+export default {
+  up: async (queryInterface: QueryInterface): Promise<void> => {
+    const transaction = await queryInterface.sequelize.transaction();
+    try {
+      // RESTRICT -> CASCADE
+      await queryInterface.removeConstraint(
+        'aplus_grade_source',
+        'aplus_grade_source_attainment_id_fkey',
+        {transaction}
+      );
+      await queryInterface.addConstraint('aplus_grade_source', {
+        type: 'foreign key',
+        fields: ['course_part_id'],
+        name: 'aplus_grade_source_course_part_id_fkey',
+        references: {table: 'course_part', field: 'id'},
+        onDelete: 'CASCADE',
+        onUpdate: 'CASCADE',
+        transaction,
+      });
+
+      await transaction.commit();
+    } catch (error) {
+      await transaction.rollback();
+      logger.error(error);
+    }
+  },
+  down: async (queryInterface: QueryInterface): Promise<void> => {
+    const transaction = await queryInterface.sequelize.transaction();
+    try {
+      // CASCADE -> RESTRICT
+      await queryInterface.removeConstraint(
+        'aplus_grade_source',
+        'aplus_grade_source_course_part_id_fkey',
+        {transaction}
+      );
+      await queryInterface.addConstraint('aplus_grade_source', {
+        type: 'foreign key',
+        fields: ['course_part_id'],
+        name: 'aplus_grade_source_attainment_id_fkey',
+        references: {table: 'course_part', field: 'id'},
+        onDelete: 'RESTRICT',
+        onUpdate: 'CASCADE',
+        transaction,
+      });
+
+      await transaction.commit();
+    } catch (error) {
+      await transaction.rollback();
+      logger.error(error);
+    }
+  },
+};

--- a/server/src/database/models/aplusGradeSource.ts
+++ b/server/src/database/models/aplusGradeSource.ts
@@ -90,7 +90,7 @@ AplusGradeSource.init(
 );
 
 CoursePart.hasMany(AplusGradeSource, {
-  onDelete: 'RESTRICT',
+  onDelete: 'CASCADE',
   onUpdate: 'CASCADE',
 });
 AplusGradeSource.belongsTo(CoursePart, {foreignKey: 'coursePartId'});


### PR DESCRIPTION
**Description of changes**
We already have constraints in place preventing deleting course parts and A+ grade sources which have grades, but when they don't have grades I see no reason to prevent deleting course parts with sources.

**Requirements**
<!--
Tick all the completed boxes or indicate that the item is not relevant to this
pull request by removing it from the list or by adding a short explanation.
-->
- [x] I have marked all new files with the correct [license](
      https://github.com/aalto-grades/base-repository/wiki/Licensing-Guidelines)

**Related issues**
Fixes #761 
