### PR TITLE
Change button text from 'Cancel' to 'Close' conditionally based on selected students

### DIFF
--- a/client/src/components/course/course-results-view/SisuDownloadDialog.tsx
+++ b/client/src/components/course/course-results-view/SisuDownloadDialog.tsx
@@ -249,7 +249,7 @@ const SisuDownloadDialog = ({
       </DialogContent>
       <DialogActions>
         <Button variant="outlined" onClick={onClose}>
-          {t('general.cancel')}
+          {exportedValuesInList ? t('general.close') : t('general.cancel')}
         </Button>
         <Button variant="contained" onClick={handleDownloadSisuGradeCsv}>
           {t('general.download')}


### PR DESCRIPTION
If selected student list include exported ones, which means that the dialog won't close after users download CSV file, the text of button is changes from "Cancel" to "Close"