### PR TITLE
Add login button to the token expired error message

### DIFF
--- a/client/public/locales/en/translation.json
+++ b/client/public/locales/en/translation.json
@@ -418,7 +418,8 @@
       "body": "If you have been provided with credentials specifically for Aalto Grades, use this login.",
       "mfa-code": "MFA code",
       "button": "Log in"
-    }
+    },
+    "login-again": "Login again"
   },
   "manage-students": {
     "latest-grade": "Latest grade",

--- a/client/public/locales/fi/translation.json
+++ b/client/public/locales/fi/translation.json
@@ -418,7 +418,8 @@
       "body": "UNTRANSLATED",
       "mfa-code": "UNTRANSLATED",
       "button": "UNTRANSLATED"
-    }
+    },
+    "login-again": "UNTRANSLATED"
   },
   "manage-students": {
     "latest-grade": "UNTRANSLATED",

--- a/client/public/locales/sv/translation.json
+++ b/client/public/locales/sv/translation.json
@@ -418,7 +418,8 @@
       "body": "UNTRANSLATED",
       "mfa-code": "UNTRANSLATED",
       "button": "UNTRANSLATED"
-    }
+    },
+    "login-again": "UNTRANSLATED"
   },
   "manage-students": {
     "latest-grade": "UNTRANSLATED",

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -38,6 +38,7 @@ import GradesView from './components/course/GradesView';
 import ModelsView from './components/course/ModelsView';
 import ConfirmDialog from './components/shared/ConfirmDialog';
 import NotistackWrapper from './context/NotistackWrapper';
+import type {CustomError} from './types';
 
 declare module '@mui/material/styles' {
   interface PaletteOptions {
@@ -200,8 +201,11 @@ const Root = (): JSX.Element => {
     GlobalModal.setUpModal(globalModalRef as Ref<GlobalModalWrapper | null>);
   }, []);
 
-  const handleError = (error: Error): void => {
-    enqueueSnackbar(error.message, {variant: 'error'});
+  const handleError = (error: CustomError): void => {
+    enqueueSnackbar(error.message, {
+      variant: 'error',
+      action: error.action,
+    });
   };
 
   const queryClient = new QueryClient({

--- a/client/src/components/shared/LoginAgainButton.tsx
+++ b/client/src/components/shared/LoginAgainButton.tsx
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: 2024 The Aalto Grades Developers
+//
+// SPDX-License-Identifier: MIT
+
+import {Button} from '@mui/material';
+import type {JSX} from 'react';
+import {useTranslation} from 'react-i18next';
+
+const LoginAgainButton = (): JSX.Element => {
+  const {t} = useTranslation();
+  const openLoginWindow = (): void => {
+    const loginWindow = window.open(
+      '/login',
+      '_blank',
+      'height=720, width=1024'
+    );
+    if (loginWindow) {
+      loginWindow.onload = () => {
+        setInterval(() => {
+          if (loginWindow.location.pathname === '/') {
+            loginWindow.close();
+          }
+        }, 500);
+      };
+    }
+  };
+  return (
+    <Button
+      variant="outlined"
+      onClick={openLoginWindow}
+      style={{color: 'white', borderColor: 'white'}}
+    >
+      {t('login.login-again')}
+    </Button>
+  );
+};
+
+export default LoginAgainButton;

--- a/client/src/context/NotistackWrapper.tsx
+++ b/client/src/context/NotistackWrapper.tsx
@@ -15,6 +15,7 @@ const NotistackWrapper = (): JSX.Element => (
     maxSnack={MAX_SNACK}
     autoHideDuration={AUTO_HIDE_DURATION}
     anchorOrigin={POSITION}
+    preventDuplicate
   />
 );
 

--- a/client/src/hooks/api/axios.ts
+++ b/client/src/hooks/api/axios.ts
@@ -6,6 +6,9 @@ import axios from 'axios';
 import i18next from 'i18next';
 import type {ZodError} from 'zod';
 
+import LoginAgainButton from '@/components/shared/LoginAgainButton';
+import {CustomError} from '@/types';
+
 const axiosInstance = axios.create({
   withCredentials: true,
   validateStatus: (status: number) => status < 600 && status >= 100,
@@ -30,7 +33,10 @@ axiosInstance.interceptors.response.use(response => {
 
   // Token expired error
   if (response.status === 401) {
-    throw new Error(i18next.t('shared.auth.token-expired'));
+    throw new CustomError({
+      message: i18next.t('shared.auth.token-expired'),
+      action: LoginAgainButton,
+    });
   }
 
   // Other errors

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -38,3 +38,13 @@ export const nullableDateSchema = (
   _t: TFunction
 ): z.ZodNullable<z.ZodPipeline<z.ZodString, z.ZodDate>> =>
   z.string().date().pipe(z.coerce.date()).nullable();
+
+export class CustomError extends Error {
+  action?: React.FC | null;
+
+  constructor({message, action}: {message: string; action: React.FC}) {
+    super();
+    this.message = message;
+    this.action = action;
+  }
+}


### PR DESCRIPTION
- Adding a button "Login again" in the snack bar when token expired. Clicking this button will open up a new window for login again and the window will close after user successfully logged in
- Preventing Snackbar showing duplicate message