### PR TITLE
Create a new jwt authentication middleware to handle error message correctly

### DIFF
--- a/client/src/hooks/api/axios.ts
+++ b/client/src/hooks/api/axios.ts
@@ -31,20 +31,20 @@ axiosInstance.interceptors.response.use(response => {
     );
   }
 
-  // Token expired error
-  if (response.status === 401) {
-    throw new CustomError({
-      message: i18next.t('shared.auth.token-expired'),
-      action: LoginAgainButton,
-    });
-  }
-
   // Other errors
   if (resData !== null && typeof resData === 'object' && 'errors' in resData) {
-    throw new Error(
-      `${response.status} - ${response.statusText}: ` +
-        resData.errors.join(', ')
-    );
+    // Token expired error
+    if (resData.errors.includes('TokenExpiredError')) {
+      throw new CustomError({
+        message: i18next.t('shared.auth.token-expired'),
+        action: LoginAgainButton,
+      });
+    } else {
+      throw new Error(
+        `${response.status} - ${response.statusText}: ` +
+          resData.errors.join(', ')
+      );
+    }
   }
 
   return response;

--- a/server/src/middleware/authentication.ts
+++ b/server/src/middleware/authentication.ts
@@ -1,0 +1,37 @@
+import type {NextFunction, Request, RequestHandler, Response} from 'express';
+import passport from 'passport';
+
+import {HttpCode} from '@/common/types/general';
+import type {JwtClaims} from '../types';
+
+export const jwtAuthentication = (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): void => {
+  const authenticate = passport.authenticate(
+    'jwt',
+    {session: false},
+    (
+      info: object | null,
+      user: JwtClaims | false | null,
+      error: object | string | Array<string | undefined>
+    ) => {
+      if (!user) {
+        if (error instanceof Error) {
+          return res.status(HttpCode.Unauthorized).send({
+            errors: [error.name],
+          });
+        } else {
+          return res.status(HttpCode.Unauthorized).send({
+            errors: ['JwtAuthenticationError'],
+          });
+        }
+      } else {
+        req.user = user;
+        next();
+      }
+    }
+  ) as RequestHandler;
+  authenticate(req, res, next);
+};

--- a/server/src/middleware/authentication.ts
+++ b/server/src/middleware/authentication.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Aalto Grades Developers
+//
+// SPDX-License-Identifier: MIT
+
 import type {NextFunction, Request, RequestHandler, Response} from 'express';
 import passport from 'passport';
 

--- a/server/src/routes/aplus.ts
+++ b/server/src/routes/aplus.ts
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: MIT
 
-import express, {type RequestHandler, Router} from 'express';
-import passport from 'passport';
+import express, {Router} from 'express';
 import {processRequestBody} from 'zod-express-middleware';
 
 import {CourseRoleType, NewAplusGradeSourceArraySchema} from '@/common/types';
@@ -15,6 +14,7 @@ import {
   fetchAplusGrades,
 } from '../controllers/aplus';
 import {handleInvalidRequestJson} from '../middleware';
+import {jwtAuthentication} from '../middleware/authentication';
 import {courseAuthorization} from '../middleware/authorization';
 import {controllerDispatcher} from '../middleware/errorHandler';
 
@@ -22,19 +22,19 @@ export const router = Router();
 
 router.get(
   '/v1/aplus/courses',
-  passport.authenticate('jwt', {session: false}) as RequestHandler,
+  jwtAuthentication,
   controllerDispatcher(fetchAplusCourses)
 );
 
 router.get(
   '/v1/aplus/courses/:aplusCourseId',
-  passport.authenticate('jwt', {session: false}) as RequestHandler,
+  jwtAuthentication,
   controllerDispatcher(fetchAplusExerciseData)
 );
 
 router.post(
   '/v1/courses/:courseId/aplus-sources',
-  passport.authenticate('jwt', {session: false}) as RequestHandler,
+  jwtAuthentication,
   courseAuthorization([CourseRoleType.Teacher]),
   express.json(),
   handleInvalidRequestJson,
@@ -44,14 +44,14 @@ router.post(
 
 router.delete(
   '/v1/courses/:courseId/aplus-sources/:aplusGradeSourceId',
-  passport.authenticate('jwt', {session: false}) as RequestHandler,
+  jwtAuthentication,
   courseAuthorization([CourseRoleType.Teacher]),
   controllerDispatcher(deleteAplusGradeSource)
 );
 
 router.get(
   '/v1/courses/:courseId/aplus-fetch',
-  passport.authenticate('jwt', {session: false}) as RequestHandler,
+  jwtAuthentication,
   courseAuthorization([CourseRoleType.Teacher, CourseRoleType.Assistant]),
   controllerDispatcher(fetchAplusGrades)
 );

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -27,6 +27,7 @@ import {
   selfInfo,
 } from '../controllers/auth';
 import {handleInvalidRequestJson} from '../middleware';
+import {jwtAuthentication} from '../middleware/authentication';
 import {authorization} from '../middleware/authorization';
 import {controllerDispatcher} from '../middleware/errorHandler';
 import {rateLimiterMemoryMiddleware} from '../middleware/rateLimiterMemory';
@@ -35,7 +36,7 @@ export const router = Router();
 
 router.get(
   '/v1/auth/self-info',
-  passport.authenticate('jwt', {session: false}) as RequestHandler,
+  jwtAuthentication,
   controllerDispatcher(selfInfo)
 );
 
@@ -49,11 +50,7 @@ router.post(
   authLogin
 );
 
-router.post(
-  '/v1/auth/logout',
-  passport.authenticate('jwt', {session: false}) as RequestHandler,
-  authLogout
-);
+router.post('/v1/auth/logout', jwtAuthentication, authLogout);
 
 // Dispatchers not needed, because not async
 router.post(
@@ -67,7 +64,7 @@ router.post(
 
 router.post(
   '/v1/auth/reset-auth/:userId',
-  passport.authenticate('jwt', {session: false}) as RequestHandler,
+  jwtAuthentication,
   authorization([SystemRole.Admin]),
   express.json(),
   handleInvalidRequestJson,
@@ -77,7 +74,7 @@ router.post(
 
 router.post(
   '/v1/auth/change-own-auth',
-  passport.authenticate('jwt', {session: false}) as RequestHandler,
+  jwtAuthentication,
   authorization([SystemRole.Admin]),
   express.json(),
   handleInvalidRequestJson,
@@ -87,7 +84,7 @@ router.post(
 
 router.post(
   '/v1/auth/confirm-mfa',
-  passport.authenticate('jwt', {session: false}) as RequestHandler,
+  jwtAuthentication,
   authorization([SystemRole.Admin]),
   express.json(),
   handleInvalidRequestJson,

--- a/server/src/routes/course.ts
+++ b/server/src/routes/course.ts
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: MIT
 
-import express, {type RequestHandler, Router} from 'express';
-import passport from 'passport';
+import express, {Router} from 'express';
 import {processRequestBody} from 'zod-express-middleware';
 
 import {
@@ -19,6 +18,7 @@ import {
   getCourse,
 } from '../controllers/course';
 import {handleInvalidRequestJson} from '../middleware';
+import {jwtAuthentication} from '../middleware/authentication';
 import {authorization, courseAuthorization} from '../middleware/authorization';
 import {controllerDispatcher} from '../middleware/errorHandler';
 
@@ -26,7 +26,7 @@ export const router = Router();
 
 router.get(
   '/v1/courses/:courseId',
-  passport.authenticate('jwt', {session: false}) as RequestHandler,
+  jwtAuthentication,
   courseAuthorization([
     CourseRoleType.Teacher,
     CourseRoleType.Assistant,
@@ -37,14 +37,14 @@ router.get(
 
 router.get(
   '/v1/courses',
-  passport.authenticate('jwt', {session: false}) as RequestHandler,
+  jwtAuthentication,
   authorization([SystemRole.Admin]),
   controllerDispatcher(getAllCourses)
 );
 
 router.post(
   '/v1/courses',
-  passport.authenticate('jwt', {session: false}) as RequestHandler,
+  jwtAuthentication,
   authorization([SystemRole.Admin, SystemRole.User]),
   express.json(),
   handleInvalidRequestJson,
@@ -54,7 +54,7 @@ router.post(
 
 router.put(
   '/v1/courses/:courseId',
-  passport.authenticate('jwt', {session: false}) as RequestHandler,
+  jwtAuthentication,
   courseAuthorization([CourseRoleType.Teacher]),
   express.json(),
   handleInvalidRequestJson,

--- a/server/src/routes/coursePart.ts
+++ b/server/src/routes/coursePart.ts
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: MIT
 
-import express, {type RequestHandler, Router} from 'express';
-import passport from 'passport';
+import express, {Router} from 'express';
 import {processRequestBody} from 'zod-express-middleware';
 
 import {
@@ -18,6 +17,7 @@ import {
   getCourseParts,
 } from '../controllers/coursePart';
 import {handleInvalidRequestJson} from '../middleware';
+import {jwtAuthentication} from '../middleware/authentication';
 import {courseAuthorization} from '../middleware/authorization';
 import {controllerDispatcher} from '../middleware/errorHandler';
 
@@ -25,7 +25,7 @@ export const router = Router();
 
 router.get(
   '/v1/courses/:courseId/parts',
-  passport.authenticate('jwt', {session: false}) as RequestHandler,
+  jwtAuthentication,
   courseAuthorization([
     CourseRoleType.Teacher,
     CourseRoleType.Assistant,
@@ -36,7 +36,7 @@ router.get(
 
 router.post(
   '/v1/courses/:courseId/parts',
-  passport.authenticate('jwt', {session: false}) as RequestHandler,
+  jwtAuthentication,
   courseAuthorization([CourseRoleType.Teacher]),
   express.json(),
   handleInvalidRequestJson,
@@ -46,7 +46,7 @@ router.post(
 
 router.put(
   '/v1/courses/:courseId/parts/:coursePartId',
-  passport.authenticate('jwt', {session: false}) as RequestHandler,
+  jwtAuthentication,
   courseAuthorization([CourseRoleType.Teacher]),
   express.json(),
   handleInvalidRequestJson,
@@ -56,7 +56,7 @@ router.put(
 
 router.delete(
   '/v1/courses/:courseId/parts/:coursePartId',
-  passport.authenticate('jwt', {session: false}) as RequestHandler,
+  jwtAuthentication,
   courseAuthorization([CourseRoleType.Teacher]),
   controllerDispatcher(deleteCoursePart)
 );

--- a/server/src/routes/courseTask.ts
+++ b/server/src/routes/courseTask.ts
@@ -2,13 +2,13 @@
 //
 // SPDX-License-Identifier: MIT
 
-import express, {type RequestHandler, Router} from 'express';
-import passport from 'passport';
+import express, {Router} from 'express';
 import {processRequestBody} from 'zod-express-middleware';
 
 import {CourseRoleType, ModifyCourseTasksSchema} from '@/common/types';
 import {getCourseTasks, modifyCourseTasks} from '../controllers/courseTask';
 import {handleInvalidRequestJson} from '../middleware';
+import {jwtAuthentication} from '../middleware/authentication';
 import {courseAuthorization} from '../middleware/authorization';
 import {controllerDispatcher} from '../middleware/errorHandler';
 
@@ -16,7 +16,7 @@ export const router = Router();
 
 router.get(
   '/v1/courses/:courseId/tasks',
-  passport.authenticate('jwt', {session: false}) as RequestHandler,
+  jwtAuthentication,
   courseAuthorization([
     CourseRoleType.Teacher,
     CourseRoleType.Assistant,
@@ -27,7 +27,7 @@ router.get(
 
 router.post(
   '/v1/courses/:courseId/tasks',
-  passport.authenticate('jwt', {session: false}) as RequestHandler,
+  jwtAuthentication,
   courseAuthorization([CourseRoleType.Teacher]),
   express.json(),
   handleInvalidRequestJson,

--- a/server/src/routes/finalGrade.ts
+++ b/server/src/routes/finalGrade.ts
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: MIT
 
-import express, {type RequestHandler, Router} from 'express';
-import passport from 'passport';
+import express, {Router} from 'express';
 import {processRequestBody} from 'zod-express-middleware';
 
 import {
@@ -20,6 +19,7 @@ import {
   getSisuFormattedGradingCSV,
 } from '../controllers/finalGrade';
 import {handleInvalidRequestJson} from '../middleware';
+import {jwtAuthentication} from '../middleware/authentication';
 import {courseAuthorization} from '../middleware/authorization';
 import {controllerDispatcher} from '../middleware/errorHandler';
 
@@ -27,14 +27,14 @@ export const router = Router();
 
 router.get(
   '/v1/courses/:courseId/final-grades',
-  passport.authenticate('jwt', {session: false}) as RequestHandler,
+  jwtAuthentication,
   courseAuthorization([CourseRoleType.Teacher, CourseRoleType.Assistant]),
   controllerDispatcher(getFinalGrades)
 );
 
 router.post(
   '/v1/courses/:courseId/final-grades',
-  passport.authenticate('jwt', {session: false}) as RequestHandler,
+  jwtAuthentication,
   courseAuthorization([CourseRoleType.Teacher]),
   express.json(),
   handleInvalidRequestJson,
@@ -44,7 +44,7 @@ router.post(
 
 router.put(
   '/v1/courses/:courseId/final-grades/:finalGradeId',
-  passport.authenticate('jwt', {session: false}) as RequestHandler,
+  jwtAuthentication,
   courseAuthorization([CourseRoleType.Teacher]),
   express.json(),
   handleInvalidRequestJson,
@@ -54,7 +54,7 @@ router.put(
 
 router.delete(
   '/v1/courses/:courseId/final-grades/:finalGradeId',
-  passport.authenticate('jwt', {session: false}) as RequestHandler,
+  jwtAuthentication,
   courseAuthorization([CourseRoleType.Teacher]),
   controllerDispatcher(deleteFinalGrade)
 );
@@ -62,7 +62,7 @@ router.delete(
 // Actually gets the csv but the request type must be post to be able to use request.body
 router.post(
   '/v1/courses/:courseId/final-grades/csv/sisu',
-  passport.authenticate('jwt', {session: false}) as RequestHandler,
+  jwtAuthentication,
   courseAuthorization([CourseRoleType.Teacher]),
   express.json({limit: '10mb'}),
   handleInvalidRequestJson,

--- a/server/src/routes/gradingModel.ts
+++ b/server/src/routes/gradingModel.ts
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: MIT
 
-import express, {type RequestHandler, Router} from 'express';
-import passport from 'passport';
+import express, {Router} from 'express';
 import {processRequestBody} from 'zod-express-middleware';
 
 import {
@@ -19,6 +18,7 @@ import {
   getGradingModel,
 } from '../controllers/gradingModel';
 import {handleInvalidRequestJson} from '../middleware';
+import {jwtAuthentication} from '../middleware/authentication';
 import {courseAuthorization} from '../middleware/authorization';
 import {controllerDispatcher} from '../middleware/errorHandler';
 
@@ -26,21 +26,21 @@ export const router = Router();
 
 router.get(
   '/v1/courses/:courseId/grading-models/:gradingModelId',
-  passport.authenticate('jwt', {session: false}) as RequestHandler,
+  jwtAuthentication,
   courseAuthorization([CourseRoleType.Teacher, CourseRoleType.Assistant]),
   controllerDispatcher(getGradingModel)
 );
 
 router.get(
   '/v1/courses/:courseId/grading-models',
-  passport.authenticate('jwt', {session: false}) as RequestHandler,
+  jwtAuthentication,
   courseAuthorization([CourseRoleType.Teacher, CourseRoleType.Assistant]),
   controllerDispatcher(getAllGradingModels)
 );
 
 router.post(
   '/v1/courses/:courseId/grading-models',
-  passport.authenticate('jwt', {session: false}) as RequestHandler,
+  jwtAuthentication,
   courseAuthorization([CourseRoleType.Teacher]),
   express.json(),
   handleInvalidRequestJson,
@@ -50,7 +50,7 @@ router.post(
 
 router.put(
   '/v1/courses/:courseId/grading-models/:gradingModelId',
-  passport.authenticate('jwt', {session: false}) as RequestHandler,
+  jwtAuthentication,
   courseAuthorization([CourseRoleType.Teacher]),
   express.json(),
   handleInvalidRequestJson,
@@ -60,7 +60,7 @@ router.put(
 
 router.delete(
   '/v1/courses/:courseId/grading-models/:gradingModelId',
-  passport.authenticate('jwt', {session: false}) as RequestHandler,
+  jwtAuthentication,
   courseAuthorization([CourseRoleType.Teacher]),
   controllerDispatcher(deleteGradingModel)
 );

--- a/server/src/routes/taskGrade.ts
+++ b/server/src/routes/taskGrade.ts
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: MIT
 
-import express, {type RequestHandler, Router} from 'express';
-import passport from 'passport';
+import express, {Router} from 'express';
 import {processRequestBody} from 'zod-express-middleware';
 
 import {
@@ -21,6 +20,7 @@ import {
   getLatestGrades,
 } from '../controllers/taskGrade';
 import {handleInvalidRequestJson} from '../middleware';
+import {jwtAuthentication} from '../middleware/authentication';
 import {authorization, courseAuthorization} from '../middleware/authorization';
 import {controllerDispatcher} from '../middleware/errorHandler';
 
@@ -28,14 +28,14 @@ export const router = Router();
 
 router.get(
   '/v1/courses/:courseId/grades',
-  passport.authenticate('jwt', {session: false}) as RequestHandler,
+  jwtAuthentication,
   courseAuthorization([CourseRoleType.Teacher, CourseRoleType.Assistant]),
   controllerDispatcher(getGrades)
 );
 
 router.post(
   '/v1/courses/:courseId/grades',
-  passport.authenticate('jwt', {session: false}) as RequestHandler,
+  jwtAuthentication,
   courseAuthorization([CourseRoleType.Teacher, CourseRoleType.Assistant]),
   express.json({limit: '25mb'}),
   handleInvalidRequestJson,
@@ -45,7 +45,7 @@ router.post(
 
 router.put(
   '/v1/courses/:courseId/grades/:gradeId',
-  passport.authenticate('jwt', {session: false}) as RequestHandler,
+  jwtAuthentication,
   courseAuthorization([CourseRoleType.Teacher, CourseRoleType.Assistant]),
   express.json(),
   handleInvalidRequestJson,
@@ -55,7 +55,7 @@ router.put(
 
 router.delete(
   '/v1/courses/:courseId/grades/:gradeId',
-  passport.authenticate('jwt', {session: false}) as RequestHandler,
+  jwtAuthentication,
   courseAuthorization([CourseRoleType.Teacher, CourseRoleType.Assistant]),
   controllerDispatcher(deleteGrade)
 );
@@ -63,7 +63,7 @@ router.delete(
 // Actually gets the data but the request type must be post to be able to use request.body
 router.post(
   '/v1/latest-grades',
-  passport.authenticate('jwt', {session: false}) as RequestHandler,
+  jwtAuthentication,
   authorization([SystemRole.Admin]),
   express.json(),
   handleInvalidRequestJson,

--- a/server/src/routes/user.ts
+++ b/server/src/routes/user.ts
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: MIT
 
-import express, {type RequestHandler, Router} from 'express';
-import passport from 'passport';
+import express, {Router} from 'express';
 import {processRequestBody, validateRequestBody} from 'zod-express-middleware';
 
 import {NewUserSchema, SystemRole, UserIdArraySchema} from '@/common/types';
@@ -17,6 +16,7 @@ import {
   getUsers,
 } from '../controllers/user';
 import {handleInvalidRequestJson} from '../middleware';
+import {jwtAuthentication} from '../middleware/authentication';
 import {authorization} from '../middleware/authorization';
 import {controllerDispatcher} from '../middleware/errorHandler';
 
@@ -24,32 +24,32 @@ export const router = Router();
 
 router.get(
   '/v1/users/own-courses',
-  passport.authenticate('jwt', {session: false}) as RequestHandler,
+  jwtAuthentication,
   controllerDispatcher(getOwnCourses)
 );
 
 router.get(
   '/v1/users/:userId/courses/',
-  passport.authenticate('jwt', {session: false}) as RequestHandler,
+  jwtAuthentication,
   controllerDispatcher(getCoursesOfUser)
 );
 
 router.get(
   '/v1/users/students',
-  passport.authenticate('jwt', {session: false}) as RequestHandler,
+  jwtAuthentication,
   controllerDispatcher(getStudents)
 );
 
 router.get(
   '/v1/users',
-  passport.authenticate('jwt', {session: false}) as RequestHandler,
+  jwtAuthentication,
   authorization([SystemRole.Admin]),
   controllerDispatcher(getUsers)
 );
 
 router.post(
   '/v1/users',
-  passport.authenticate('jwt', {session: false}) as RequestHandler,
+  jwtAuthentication,
   authorization([SystemRole.Admin]),
   express.json(),
   handleInvalidRequestJson,
@@ -59,14 +59,14 @@ router.post(
 
 router.delete(
   '/v1/users/:userId',
-  passport.authenticate('jwt', {session: false}) as RequestHandler,
+  jwtAuthentication,
   authorization([SystemRole.Admin]),
   controllerDispatcher(deleteUser)
 );
 
 router.post(
   '/v1/users/delete',
-  passport.authenticate('jwt', {session: false}) as RequestHandler,
+  jwtAuthentication,
   authorization([SystemRole.Admin]),
   express.json(),
   handleInvalidRequestJson,

--- a/server/test/util/responses.ts
+++ b/server/test/util/responses.ts
@@ -66,7 +66,10 @@ export class ResponseTests {
   }
 
   /** Send a request and expect a 401 unauthorized */
-  testUnauthorized(url: string, expected: string = '{}'): ReturnType {
+  testUnauthorized(
+    url: string,
+    expected: string = '{"errors":["Error"]}'
+  ): ReturnType {
     const call = async (request: Test): Promise<void> => {
       const res = await request
         .set('Accept', 'application/json')


### PR DESCRIPTION
- Backend: Create our own middleware for JWT authentication that still mainly use passportJs lib but added new callback to handle error messages
- Frontend: Modify axios interceptor to handle the error messages including the case that token expired