### PR TITLE
Fix auto recreate reverse proxy watch tower

### DIFF
--- a/docker-compose-from-images-dev.yaml
+++ b/docker-compose-from-images-dev.yaml
@@ -12,6 +12,9 @@ services:
     extends:
       file: ./docker-compose-from-images.yaml
       service: reverse-proxy
+    depends_on:
+      - frontend
+      - backend
 
   frontend:
     extends:

--- a/docker-compose-from-images-dev.yaml
+++ b/docker-compose-from-images-dev.yaml
@@ -51,4 +51,4 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
     # To use the local smtp server of aalto vm
     network_mode: host
-    command: --interval 600 --cleanup
+    command: --interval 3600 --cleanup


### PR DESCRIPTION
- Add the depends_on property for the reverse proxy service in the dev file because the depends_on can not be extended.
- Update the interval of watch tower from 10 minutes to 1 hour